### PR TITLE
RINEX Substract: fix behavior

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -202,38 +202,58 @@ pub enum FormattingError {
 pub enum Error {
     /// Invalid frequency
     InvalidFrequency,
+
+    /// Sampling Period is not determined
+    UndeterminedSamplingPeriod,
+
     /// Unknown frequency
     UnknownFrequency,
+
     /// Non supported GPS [Observable]
     UnknownGPSObservable,
+
     /// Non supported Galileo [Observable]
     UnknownGalieoObservable,
+
     /// Non supported Glonass [Observable]
     UnknownGlonassObservable,
+
     /// Non supported QZSS [Observable]
     UnknownQZSSObservable,
+
     /// Non supported BDS [Observable]
     UnknownBeiDouObservable,
+
     /// Non supported IRNSS [Observable]
     UnknownIRNSSObservable,
+
     /// Non supported SBAS [Observable]
     UnknownSBASObservable,
+
     /// Non supported DORIS [Observable]
     UnknownDORISObservable,
+
     /// Unknown GPS Frequency
     UnknownGPSFrequency,
+
     /// Unknown Galileo Frequency
     UnknownGalileoFrequency,
+
     /// Unknown QZSS Frequency
     UnknownQzssFrequency,
+
     /// Unknown Glonass Frequency
     UnknownGlonassFrequency,
+
     /// Unknown BDS Frequency
     UnknownBDSFrequency,
+
     /// Unknown IRNSS Frequency
     UnknownIRNSSFrequency,
+
     /// Unknown SBAS Frequency
     UnknownSBASFrequency,
+
     /// Unknown DORIS Frequency
     UnknownDORISFrequency,
 }

--- a/src/tests/toolkit/observation.rs
+++ b/src/tests/toolkit/observation.rs
@@ -156,7 +156,7 @@ pub fn generic_observation_rinex_test(
     assert_eq!(content, expected);
 
     // Self - Self should be 0
-    let null_dut = dut.observation_substract(&dut);
+    let null_dut = dut.observations_substract(&dut);
     generic_null_rinex_test(&null_dut);
 
     // Test clock data points


### PR DESCRIPTION
   * only keep differentiated symbols
   * allow +/- dt for match window